### PR TITLE
Added validation for valid ranges in Range ctor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,10 @@ where
     Idx: PartialOrd,
 {
     /// Construct a [Range] that counts up to the given item.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when trying to create a [Range] where the upper bound is less than the lower bound.
     pub fn up_to(self, x: Idx) -> Range<Idx, Upwards> {
         if self.from > x {
             panic!("Invalid range: upper bound cannot be lesser than lower bound!");
@@ -65,6 +69,10 @@ where
     }
 
     /// Construct a [Range] that counts down to the given item.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when trying to create a [Range] where the lower bound is less than the upper bound.
     pub fn down_to(self, x: Idx) -> Range<Idx, Downwards> {
         if self.from < x {
             panic!("Invalid range: lower bound cannot be lesser than upper bound!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,16 @@ pub struct From<Idx> {
     from: Idx,
 }
 
-impl<Idx> From<Idx> {
+impl<Idx> From<Idx>
+where
+    Idx: PartialOrd,
+{
     /// Construct a [Range] that counts up to the given item.
     pub fn up_to(self, x: Idx) -> Range<Idx, Upwards> {
+        if self.from > x {
+            panic!("Invalid range: upper bound cannot be lesser than lower bound!");
+        }
+
         Range {
             from: self.from,
             to: x,
@@ -59,6 +66,10 @@ impl<Idx> From<Idx> {
 
     /// Construct a [Range] that counts down to the given item.
     pub fn down_to(self, x: Idx) -> Range<Idx, Downwards> {
+        if self.from < x {
+            panic!("Invalid range: lower bound cannot be lesser than upper bound!");
+        }
+
         Range {
             from: self.from,
             to: x,
@@ -318,4 +329,30 @@ fn as_std_range_inclusive() {
 
     assert_eq!(u, vec![10, 11, 12, 13, 14]);
     assert_eq!(v, vec![10, 11, 12, 13, 14]);
+}
+
+#[test]
+#[should_panic]
+fn fail_up_to_invalid_range() {
+    from(40).up_to(39);
+}
+
+#[test]
+#[should_panic]
+fn fail_down_to_invalid_range() {
+    from(40).down_to(41);
+}
+
+#[test]
+fn up_to_equivalent_val() {
+    let r = from(10).up_to(10);
+
+    assert_eq!(r.to_vec(), vec![10]);
+}
+
+#[test]
+fn down_to_equivalent_val() {
+    let r = from(10).down_to(10);
+
+    assert_eq!(r.to_vec(), vec![10]);
 }


### PR DESCRIPTION
By default, Ranges are end inclusive. So single element Ranges (e.g. from(10).up_to(10)) are ok!

Fixes #6 

- [x] `from(n).up_to(n-1)` should fail
- [x] `from(n).down_to(n+1)` should fail
- [x] What should `from(n).up_to(n)` and `from(n).down_to(n)` do? Nothing?
  > Single element Ranges (e.g. from(10).up_to(10)) are ok!