### PR TITLE
Include package-level docs from README.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,12 @@ repository = "https://github.com/killercup/a-range"
 [dependencies]
 num-traits = "0.2.6"
 
+[features]
+nightly = []
+
 [badges]
 travis-ci = { repository = "killercup/a-range" }
+
+[package.metadata.docs.rs]
+features = ["nightly"]
+no-default-features = true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 [![crates.io](https://img.shields.io/crates/v/a-range.svg)](https://crates.io/crates/a-range)
 [![docs](https://img.shields.io/badge/api_docs-latest-blue.svg)](https://docs.rs/a-range)
 
+Create ranges in a very explicit manner
+
+Start with the [`from()`] function and build up a range using [`From::up_to`] or
+[`From::down_to`].
+
+# Examples
+
+```rust
+extern crate a_range;
+
+let x = a_range::from(5).up_to(7);
+assert_eq!(x.to_vec(), vec![5, 6, 7]);
+
+let x = a_range::from(3).down_to(1);
+assert_eq!(x.to_vec(), vec![3, 2, 1]);
+```
+
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,5 @@
-//! Create ranges in a very explicit manner
-//!
-//! Start with the [`from()`] function and build up a range using [`From::up_to`] or
-//! [`From::down_to`].
-//!
-//! # Examples
-//!
-//! ```rust
-//! extern crate a_range;
-//!
-//! let x = a_range::from(5).up_to(7);
-//! assert_eq!(x.to_vec(), vec![5, 6, 7]);
-//!
-//! let x = a_range::from(3).down_to(1);
-//! assert_eq!(x.to_vec(), vec![3, 2, 1]);
-//! ```
-
+#![cfg_attr(feature = "nightly", feature(external_doc))]
+#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![warn(missing_docs)]
 
 extern crate num_traits;


### PR DESCRIPTION
Solves #13. Generates the package-level documentation (located on the crate's docs.rs homepage) based on the contents of [README.md](https://github.com/killercup/a-range/blob/master/README.md). When on the nightly compiler, the docs can be generated like so:
```
$ cargo doc --features nightly
```
NOTE: After moving the top-level doc comments from [src/lib.rs](https://github.com/killercup/a-range/blob/master/src/lib.rs) into [README.md](https://github.com/killercup/a-range/blob/master/README.md), Rust Doc links (such as ``[`from()`]``) appear with the brackets in the README. I tried adding parens after the brackets, to make them dead links in the README, but then Rust Doc doesn't recognize them as links to the item documentation.