### PR TITLE
Added crate-level doc tests to demo single element range behaviour.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,20 @@
 //! let x = a_range::from(3).down_to(1);
 //! assert_eq!(x.to_vec(), vec![3, 2, 1]);
 //! ```
+//!
+//! Note that the created ranges are _ends-inclusive._
+//!
+//! Single element ranges are also possible!
+//!
+//! ```rust
+//! # extern crate a_range;
+//!
+//! let up_range = a_range::from(10).up_to(10);
+//! assert_eq!(up_range.to_vec(), vec![10]);
+//!
+//! let down_range = a_range::from(10).down_to(10);
+//! assert_eq!(down_range.to_vec(), vec![10]);
+//! ```
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Fixes #12 .

> We should
- [x] document this behavior (either in the crate-level docs or in the docs for up_to/down_to) and
- [x] make these unit tests doc tests

I haven't removed the unit tests at the bottom of the file, yet. Let's wait until we've moved to doc tests as much as possible.

