### PR TITLE
Integrate docmatic tests for README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ num-traits = "0.2.6"
 
 [dev-dependencies]
 proptest = "0.8.7"
+docmatic = "0.1"
 
 [badges]
 travis-ci = { repository = "killercup/a-range" }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@
 [![crates.io](https://img.shields.io/crates/v/a-range.svg)](https://crates.io/crates/a-range)
 [![docs](https://img.shields.io/badge/api_docs-latest-blue.svg)](https://docs.rs/a-range)
 
+## Example
+
+```rust
+extern crate a_range;
+
+// Create upward-counting inclusive ranges
+let days_of_xmas = a_range::from(1).up_to(12);
+let expected = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+assert_eq!(days_of_xmas.to_vec(), expected);
+
+// Just as easily count backwards
+let apollo_countdown = a_range::from(100).down_to(0);
+let expected: Vec<i32> = (0..101).rev().collect();
+assert_eq!(apollo_countdown.to_vec(), expected);
+
+// Infinite ranges are also fun
+let naturals = a_range::from(0).up_to_infinity();
+let until_four: Vec<i32> = naturals.into_iter().take(5).collect();
+assert_eq!(until_four, vec![0, 1, 2, 3, 4]);
+```
+
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ extern crate num_traits;
 #[macro_use]
 extern crate proptest;
 
+#[cfg(test)]
+extern crate docmatic;
+
 use num_traits::{Bounded, One};
 use std::iter::FromIterator;
 use std::ops::{AddAssign, SubAssign};
@@ -400,6 +403,11 @@ where
 
         Some(self.current.clone())
     }
+}
+
+#[test]
+fn readme_code_examples() {
+    docmatic::assert_file("README.md");
 }
 
 #[test]


### PR DESCRIPTION
Addresses #13. Adds new examples to the README, and integrates the [docmatic](https://docs.rs/crate/docmatic/0.1.2) crate which tests these examples when `cargo test` is run.